### PR TITLE
Migrating to AndroidX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.3.0
+## 1.0.3
 
 * Support Android X. There might be build issue when using this version. If it so, you either migrate to Android X or using previous version. 
 * Breaking change. Migrate from the deprecated original Android Support Library to AndroidX. This shouldn't result in any functional changes, but it requires any Android apps using this plugin to also migrate if they're using the original support library.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.3.0
+
+* Support Android X. There might be build issue when using this version. If it so, you either migrate to Android X or using previous version. 
+* Breaking change. Migrate from the deprecated original Android Support Library to AndroidX. This shouldn't result in any functional changes, but it requires any Android apps using this plugin to also migrate if they're using the original support library.
+
 ## 1.0.2
 Added zoom for ios
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.2'
+        classpath 'com.android.tools.build:gradle:3.3.1'
     }
 }
 
@@ -22,7 +22,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
 
     defaultConfig {
         minSdkVersion 16

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,3 +1,1 @@
-android.enableJetifier=true
-android.useAndroidX=true
 org.gradle.jvmargs=-Xmx1536M

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,1 +1,3 @@
+android.enableJetifier=true
+android.useAndroidX=true
 org.gradle.jvmargs=-Xmx1536M

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_full_pdf_viewer
 description: A fully functional on both platforms pdf viewer.
-version: 1.0.2
+version: 1.0.3
 author: Alban Veliu <alveliu93<@gmail.com>
 homepage: https://github.com/albo1337
 


### PR DESCRIPTION
## 1.0.3

* Support Android X. There might be build issue when using this version. If it so, you either migrate to Android X or using previous version. 
* Breaking change. Migrate from the deprecated original Android Support Library to AndroidX. This shouldn't result in any functional changes, but it requires any Android apps using this plugin to also migrate if they're using the original support library.