### PR TITLE
Feature/page functions

### DIFF
--- a/android/src/main/java/com/alveliu/flutterfullpdfviewer/FlutterFullPdfViewerManager.java
+++ b/android/src/main/java/com/alveliu/flutterfullpdfviewer/FlutterFullPdfViewerManager.java
@@ -5,6 +5,8 @@ import android.view.ViewGroup;
 import android.widget.FrameLayout;
 
 import com.github.barteksc.pdfviewer.PDFView;
+import com.github.barteksc.pdfviewer.listener.OnPageChangeListener;
+import android.util.Log;
 
 import java.io.File;
 
@@ -14,25 +16,57 @@ import io.flutter.plugin.common.MethodChannel;
 /**
  * FlutterFullPdfViewerManager
  */
-class FlutterFullPdfViewerManager {
+class FlutterFullPdfViewerManager implements OnPageChangeListener {
 
     boolean closed = false;
     PDFView pdfView;
     Activity activity;
+    String pdfFileName;
+    Boolean testChange= true;
+    Integer pageNumber = 0;
 
     FlutterFullPdfViewerManager (final Activity activity) {
         this.pdfView = new PDFView(activity, null);
         this.activity = activity;
     }
 
+    @Override
+    public void onPageChanged(int page, int pageCount) {
+        this.pageNumber = page;
+        this.activity.setTitle(String.format("%s %s / %s", pdfFileName, page + 1, pageCount));
+    }
+
     void openPDF(String path) {
+        Log.e("openPDF",path);
+
         File file = new File(path);
+        this.pdfFileName = file.getName();
+
         pdfView.fromFile(file)
                 .enableSwipe(true)
                 .swipeHorizontal(false)
                 .enableDoubletap(true)
+                .onPageChange(this)
                 .defaultPage(0)
                 .load();
+    }
+
+    int getPageCount() {
+        if (pdfView == null) {
+            return 0;
+        }
+        return pdfView.getPageCount();
+    }
+
+    int setPage(int page){
+        pdfView.jumpTo(page);
+        pageNumber = page;
+        Log.e("pageNumber",pageNumber.toString());
+        return pageNumber;
+    }
+
+    int getPage(){
+        return pdfView.getCurrentPage();
     }
 
     void resize(FrameLayout.LayoutParams params) {

--- a/android/src/main/java/com/alveliu/flutterfullpdfviewer/FlutterFullPdfViewerPlugin.java
+++ b/android/src/main/java/com/alveliu/flutterfullpdfviewer/FlutterFullPdfViewerPlugin.java
@@ -41,19 +41,56 @@ public class FlutterFullPdfViewerPlugin implements MethodCallHandler, PluginRegi
     @Override
     public void onMethodCall(MethodCall call, Result result) {
         switch (call.method) {
-            case "launch":
-                openPDF(call, result);
-                break;
-            case "resize":
-                resize(call, result);
-                break;
-            case "close":
-                close(call, result);
-                break;
-            default:
-                result.notImplemented();
-                break;
+        case "launch":
+            openPDF(call, result);
+            break;
+        case "resize":
+            resize(call, result);
+            break;
+        case "getPageCount":
+            getPageCount(call, result);
+            break;
+        case "getPage":
+            getPage(call, result);
+            break;
+        case "setPage":
+            setPage(call, result);
+            break;
+        case "close":
+            close(call, result);
+            break;
+        default:
+            result.notImplemented();
+            break;
         }
+    }
+
+    public int getPageCount(MethodCall call, final MethodChannel.Result result) {
+        int page = -1;
+        if (flutterFullPdfViewerManager != null) {
+            page = flutterFullPdfViewerManager.getPageCount();
+        }
+        result.success(Integer.toString(page));
+        return page;
+    }
+
+    public int getPage(MethodCall call, final MethodChannel.Result result) {
+        int page = -1;
+        if (flutterFullPdfViewerManager != null) {
+            page = flutterFullPdfViewerManager.getPage() + 1;
+        }
+        result.success(Integer.toString(page));
+        return page;
+    }
+
+    public int setPage(MethodCall call, final MethodChannel.Result result) {
+        Map<String, Number> rc = call.argument("rect");
+        int page = -1;
+        if (flutterFullPdfViewerManager != null) {
+            page = flutterFullPdfViewerManager.setPage(rc.get("page").intValue()-1) + 1;
+        }
+        result.success(Integer.toString(page));
+        return page;
     }
 
     private void openPDF(MethodCall call, MethodChannel.Result result) {

--- a/ios/Classes/FlutterFullPdfViewerPlugin.m
+++ b/ios/Classes/FlutterFullPdfViewerPlugin.m
@@ -16,6 +16,60 @@
     #define isIOSAbove4 ([[[UIDevice currentDevice] systemVersion] floatValue] >= 5.0)
 }
 
+// @interface CaptionViewController () <UIScrollViewDelegate>
+
+
+
+
+// #pragma UIScrollViewDelegate
+// -(void)scrollViewDidScroll:(UIScrollView *)scrollView
+// {
+//     // if pdfPageHeight is -1 it needs to be calculated
+//     if(_pdfPageHeight == -1)
+//     {
+//         // the page height is calculated by taking the overall size of the UIWebView scrollView content size
+//         // then dividing it by the number of pages Core Graphics reported for the PDF file being shown
+//         CGFloat contentHeight = _webView.scrollView.contentSize.height;
+//          _pdfPageHeight = contentHeight / _pageCount;
+//         // also calculate what half the screen height is. no sense in doing this multiple times.
+//         _halfScreenHeight = (_webView.frame.size.height / 2);
+//     }
+//     // to calculate the page number, first get how far the user has scrolled
+//     float verticalContentOffset = _webView.scrollView.contentOffset.y;
+//     // next add the halfScreenHeight then divide the result by the guesstimated pdfPageHeight
+//     _pageNumber = ceilf((verticalContentOffset + _halfScreenHeight) / _pdfPageHeight);
+//     _pageNumber = 10;
+    
+//     // finally set the text of the page counter label
+//     // self.pageLabel.text 
+//     // _webView.label = [NSString stringWithFormat:@"%d of %d", _pageNumber, _pageCount];
+//     _viewController.title = [NSString stringWithFormat:@"%d of %d", _pageNumber, _pageCount];
+// }
+// @end
+
+// class ViewController: UIViewController, UIScrollViewDelegate{
+
+// //In viewDidLoad Set delegate method to self.
+
+// @IBOutlet var mainScrollView: UIScrollView!
+
+// override func viewDidLoad() {
+//     super.viewDidLoad()
+
+//     self.mainScrollView.delegate = self
+
+// }
+// //And finally you implement the methods you want your class to get.
+// func scrollViewDidScroll(_ scrollView: UIScrollView!) {
+//     // This will be called every time the user scrolls the scroll view with their finger
+//     // so each time this is called, contentOffset should be different.
+
+//     print(self.mainScrollView.contentOffset.y)
+
+//     //Additional workaround here.
+// }
+// }
+
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {
     FlutterMethodChannel* channel = [FlutterMethodChannel
                                      methodChannelWithName:@"flutter_full_pdf_viewer"
@@ -90,7 +144,7 @@
             NSDictionary *rect = call.arguments[@"rect"];
             int page =[[rect valueForKey:@"page"] doubleValue];
             page = [self setPage:page];
-            result([@"" stringByAppendingString:[NSString stringWithFormat:@"%i", [self getPage]+1]]); 
+            result([@"" stringByAppendingString:[NSString stringWithFormat:@"%i", page]]); 
         } else
         result(nil);    
     } else if ([@"resize" isEqualToString:call.method]) {
@@ -121,9 +175,9 @@
         _halfScreenHeight = (_webView.frame.size.height / 2);
     }
     /*which page? u want to go ?*/  /*how many pages?*/
-    if (page< _pageCount)
+    if (page<= _pageCount)
     {
-        float y =  _pdfPageHeight/*page Hight*/ * page++;
+        float y =  _pdfPageHeight/*page Hight*/ * (page-1);
 
         if (isIOSAbove4)
         {
@@ -134,13 +188,28 @@
             [_webView stringByEvaluatingJavaScriptFromString:[NSString stringWithFormat:@"window.scrollTo(0.0, %f)", y]];
         }
     }
-    _pageNumber = page-1;
+    _pageNumber = page;
     NSLog( @"setPage: '%i'", _pageNumber );
 
     return _pageNumber;
 }
 
 - (int)getPage {
+    // if pdfPageHeight is -1 it needs to be calculated
+    if(_pdfPageHeight == -1)
+    {
+        // the page height is calculated by taking the overall size of the UIWebView scrollView content size
+        // then dividing it by the number of pages Core Graphics reported for the PDF file being shown
+        CGFloat contentHeight = _webView.scrollView.contentSize.height;
+         _pdfPageHeight = contentHeight / _pageCount;
+        // also calculate what half the screen height is. no sense in doing this multiple times.
+        _halfScreenHeight = (_webView.frame.size.height / 2);
+    }
+    // to calculate the page number, first get how far the user has scrolled
+    float verticalContentOffset = _webView.scrollView.contentOffset.y;
+    // next add the halfScreenHeight then divide the result by the guesstimated pdfPageHeight
+    _pageNumber = ceilf((verticalContentOffset + _halfScreenHeight) / _pdfPageHeight) -1;
+    // _pageNumber = 10;
     return _pageNumber;
 }
 

--- a/ios/Classes/FlutterFullPdfViewerPlugin.m
+++ b/ios/Classes/FlutterFullPdfViewerPlugin.m
@@ -16,60 +16,6 @@
     #define isIOSAbove4 ([[[UIDevice currentDevice] systemVersion] floatValue] >= 5.0)
 }
 
-// @interface CaptionViewController () <UIScrollViewDelegate>
-
-
-
-
-// #pragma UIScrollViewDelegate
-// -(void)scrollViewDidScroll:(UIScrollView *)scrollView
-// {
-//     // if pdfPageHeight is -1 it needs to be calculated
-//     if(_pdfPageHeight == -1)
-//     {
-//         // the page height is calculated by taking the overall size of the UIWebView scrollView content size
-//         // then dividing it by the number of pages Core Graphics reported for the PDF file being shown
-//         CGFloat contentHeight = _webView.scrollView.contentSize.height;
-//          _pdfPageHeight = contentHeight / _pageCount;
-//         // also calculate what half the screen height is. no sense in doing this multiple times.
-//         _halfScreenHeight = (_webView.frame.size.height / 2);
-//     }
-//     // to calculate the page number, first get how far the user has scrolled
-//     float verticalContentOffset = _webView.scrollView.contentOffset.y;
-//     // next add the halfScreenHeight then divide the result by the guesstimated pdfPageHeight
-//     _pageNumber = ceilf((verticalContentOffset + _halfScreenHeight) / _pdfPageHeight);
-//     _pageNumber = 10;
-    
-//     // finally set the text of the page counter label
-//     // self.pageLabel.text 
-//     // _webView.label = [NSString stringWithFormat:@"%d of %d", _pageNumber, _pageCount];
-//     _viewController.title = [NSString stringWithFormat:@"%d of %d", _pageNumber, _pageCount];
-// }
-// @end
-
-// class ViewController: UIViewController, UIScrollViewDelegate{
-
-// //In viewDidLoad Set delegate method to self.
-
-// @IBOutlet var mainScrollView: UIScrollView!
-
-// override func viewDidLoad() {
-//     super.viewDidLoad()
-
-//     self.mainScrollView.delegate = self
-
-// }
-// //And finally you implement the methods you want your class to get.
-// func scrollViewDidScroll(_ scrollView: UIScrollView!) {
-//     // This will be called every time the user scrolls the scroll view with their finger
-//     // so each time this is called, contentOffset should be different.
-
-//     print(self.mainScrollView.contentOffset.y)
-
-//     //Additional workaround here.
-// }
-// }
-
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {
     FlutterMethodChannel* channel = [FlutterMethodChannel
                                      methodChannelWithName:@"flutter_full_pdf_viewer"

--- a/ios/Classes/FlutterFullPdfViewerPlugin.m
+++ b/ios/Classes/FlutterFullPdfViewerPlugin.m
@@ -9,6 +9,11 @@
     FlutterResult _result;
     UIViewController *_viewController;
     UIWebView *_webView;
+    int _pdfPageHeight;
+    int _halfScreenHeight;
+    int _pageNumber;
+    int _pageCount;
+    #define isIOSAbove4 ([[[UIDevice currentDevice] systemVersion] floatValue] >= 5.0)
 }
 
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {
@@ -53,18 +58,41 @@
         NSString *path = call.arguments[@"path"];
         
         CGRect rc = [self parseRect:rect];
+
+        NSLog( @"launch: Page: '%i'", _pageNumber );
         
         if (_webView == nil){
             _webView = [[UIWebView alloc] initWithFrame:rc];
             _webView.scalesPageToFit = true;
+            _pdfPageHeight = -1;
             
             NSURL *targetURL = [NSURL fileURLWithPath:path];
+            CGPDFDocumentRef pdfDocument = CGPDFDocumentCreateWithURL((__bridge CFURLRef)targetURL);
             NSURLRequest *request = [NSURLRequest requestWithURL:targetURL];
             [_webView loadRequest:request];
             
             [_viewController.view addSubview:_webView];
+            _pageCount = (int)CGPDFDocumentGetNumberOfPages(pdfDocument);
+            // [self setPage:10];
         }
-        
+    } else if ([@"getPageCount" isEqualToString:call.method]) {
+        if (_webView != nil) {
+            result([@"" stringByAppendingString:[NSString stringWithFormat:@"%i", [self getPageCount]]]);
+        } else
+        result(nil);
+    } else if ([@"getPage" isEqualToString:call.method]) {
+        if (_webView != nil) {
+            result([@"" stringByAppendingString:[NSString stringWithFormat:@"%i", [self getPage]+1]]);
+        } else
+        result(nil); 
+    } else if ([@"setPage" isEqualToString:call.method]) {
+        if (_webView != nil) {
+            NSDictionary *rect = call.arguments[@"rect"];
+            int page =[[rect valueForKey:@"page"] doubleValue];
+            page = [self setPage:page];
+            result([@"" stringByAppendingString:[NSString stringWithFormat:@"%i", [self getPage]+1]]); 
+        } else
+        result(nil);    
     } else if ([@"resize" isEqualToString:call.method]) {
         if (_webView != nil) {
             NSDictionary *rect = call.arguments[@"rect"];
@@ -78,6 +106,46 @@
     else {
         result(FlutterMethodNotImplemented);
     }
+}
+
+
+
+-(int)setPage:(int)page {
+    if(_pdfPageHeight == -1)
+    {
+        // the page height is calculated by taking the overall size of the UIWebView scrollView content size
+        // then dividing it by the number of pages Core Graphics reported for the PDF file being shown
+        CGFloat contentHeight = _webView.scrollView.contentSize.height;
+        _pdfPageHeight = contentHeight / _pageCount;
+        // also calculate what half the screen height is. no sense in doing this multiple times.
+        _halfScreenHeight = (_webView.frame.size.height / 2);
+    }
+    /*which page? u want to go ?*/  /*how many pages?*/
+    if (page< _pageCount)
+    {
+        float y =  _pdfPageHeight/*page Hight*/ * page++;
+
+        if (isIOSAbove4)
+        {
+            [[_webView scrollView] setContentOffset:CGPointMake(0,y) animated:YES];
+        }
+        else
+        {
+            [_webView stringByEvaluatingJavaScriptFromString:[NSString stringWithFormat:@"window.scrollTo(0.0, %f)", y]];
+        }
+    }
+    _pageNumber = page-1;
+    NSLog( @"setPage: '%i'", _pageNumber );
+
+    return _pageNumber;
+}
+
+- (int)getPage {
+    return _pageNumber;
+}
+
+- (int)getPageCount {
+    return _pageCount;
 }
 
 - (void)closeWebView {

--- a/lib/full_pdf_viewer_plugin.dart
+++ b/lib/full_pdf_viewer_plugin.dart
@@ -7,7 +7,7 @@ import 'package:flutter/services.dart';
 enum PDFViewState { shouldStart, startLoad, finishLoad }
 
 class PDFViewerPlugin {
-  final _channel = const MethodChannel("flutter_full_pdf_viewer");
+  static const _channel = const MethodChannel("flutter_full_pdf_viewer");
   static PDFViewerPlugin _instance;
 
   factory PDFViewerPlugin() => _instance ??= new PDFViewerPlugin._();
@@ -36,6 +36,41 @@ class PDFViewerPlugin {
       };
     }
     await _channel.invokeMethod('launch', args);
+  }
+
+  static Future<int> get getPageCount async {
+    final String pageCount = await _channel.invokeMethod('getPageCount');
+    print("pagecount: "+ pageCount.toString());
+    return int.parse(pageCount);
+  }
+
+  static Future<int> get getPage async {
+
+    String page = "-1";
+    try {
+      page = await _channel.invokeMethod('getPage');
+      print("page: "+page);
+    } catch (e) {
+      print(e.toString());
+    }
+    
+    return int.parse(page);
+  }
+
+  static Future<int> setPage(int currPage) async {
+    final args = {};
+    args['rect'] = {
+      'page': currPage
+    };
+    String page = "-1";
+    try {
+      page = await _channel.invokeMethod('setPage', args);
+      print(" set page: " + page);
+    } catch (e) {
+      print(e.toString());
+    }
+    
+    return int.parse(page);
   }
 
   /// Close the PDFViewer


### PR DESCRIPTION
working fix for pull #8 !!!!

fixes: #27 part of #6 

example of use case

```dart
onPressed: () async {
                print('testing page');
                var pageCount = await PDFViewerPlugin.getPageCount;
                print(pageCount);

                var page = await PDFViewerPlugin.getPage;

                print(page);

                page = await PDFViewerPlugin.setPage(13);

                print(page);

                page = await PDFViewerPlugin.getPage;

                print(page);

              }
```

description:
works for both android and ios
you can get the page count, current page, and set pages (starting at 1). Does not do page validation your application should do that. ios gets the current page by calculating the webview height will need to be updated when using a native ios pdf renderer. android updates the current page on any scrolling. Could do this for ios, but rather difficult extend the UIViewController and change page number in objective-c.