### PR TITLE
Remove the words "new" to adapt to Dart 2

### DIFF
--- a/lib/full_pdf_viewer_plugin.dart
+++ b/lib/full_pdf_viewer_plugin.dart
@@ -10,12 +10,12 @@ class PDFViewerPlugin {
   final _channel = const MethodChannel("flutter_full_pdf_viewer");
   static PDFViewerPlugin _instance;
 
-  factory PDFViewerPlugin() => _instance ??= new PDFViewerPlugin._();
+  factory PDFViewerPlugin() => _instance ??= PDFViewerPlugin._();
   PDFViewerPlugin._() {
     _channel.setMethodCallHandler(_handleMessages);
   }
 
-  final _onDestroy = new StreamController<Null>.broadcast();
+  final _onDestroy = StreamController<Null>.broadcast();
   Stream<Null> get onDestroy => _onDestroy.stream;
   Future<Null> _handleMessages(MethodCall call) async {
     switch (call.method) {

--- a/lib/full_pdf_viewer_scaffold.dart
+++ b/lib/full_pdf_viewer_scaffold.dart
@@ -17,11 +17,11 @@ class PDFViewerScaffold extends StatefulWidget {
   }) : super(key: key);
 
   @override
-  _PDFViewScaffoldState createState() => new _PDFViewScaffoldState();
+  _PDFViewScaffoldState createState() => _PDFViewScaffoldState();
 }
 
 class _PDFViewScaffoldState extends State<PDFViewerScaffold> {
-  final pdfViwerRef = new PDFViewerPlugin();
+  final pdfViwerRef = PDFViewerPlugin();
   Rect _rect;
   Timer _resizeTimer;
 
@@ -51,7 +51,7 @@ class _PDFViewScaffoldState extends State<PDFViewerScaffold> {
       if (_rect != rect) {
         _rect = rect;
         _resizeTimer?.cancel();
-        _resizeTimer = new Timer(new Duration(milliseconds: 300), () {
+        _resizeTimer = Timer(new Duration(milliseconds: 300), () {
           pdfViwerRef.resize(_rect);
         });
       }
@@ -73,6 +73,6 @@ class _PDFViewScaffoldState extends State<PDFViewerScaffold> {
       height = 0.0;
     }
 
-    return new Rect.fromLTWH(0.0, top, mediaQuery.size.width, height);
+    return Rect.fromLTWH(0.0, top, mediaQuery.size.width, height);
   }
 }


### PR DESCRIPTION
Hello,

In this PR I removed the words "new" from the code.

According to the version of Dart 2, it is no longer needed.

It can be seen in [this](https://medium.com/dartlang/announcing-dart-2-80ba01f43b6#da82) article.

:)