### PR TITLE
example should include ".pdf" extension. Otherwise a blank screen is shown in IOS 13.3.1

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -39,7 +39,7 @@ class _MyAppState extends State<MyApp> {
     var response = await request.close();
     var bytes = await consolidateHttpClientResponseBytes(response);
     String dir = (await getApplicationDocumentsDirectory()).path;
-    File file = new File('$dir/$filename');
+    File file = new File('$dir/$filename.pdf');
     await file.writeAsBytes(bytes);
     return file;
   }


### PR DESCRIPTION
example should include ".pdf" extension. Otherwise a blank screen is shown in IOS 13.3.1