### PR TITLE
Allow preferred size bottom bar

### DIFF
--- a/lib/full_pdf_viewer_scaffold.dart
+++ b/lib/full_pdf_viewer_scaffold.dart
@@ -6,12 +6,14 @@ import 'package:flutter_full_pdf_viewer/full_pdf_viewer_plugin.dart';
 
 class PDFViewerScaffold extends StatefulWidget {
   final PreferredSizeWidget appBar;
+  final PreferredSizeWidget bottomNavigationBar;
   final String path;
   final bool primary;
 
   const PDFViewerScaffold({
     Key key,
     this.appBar,
+    this.bottomNavigationBar,
     @required this.path,
     this.primary = true,
   }) : super(key: key);
@@ -58,17 +60,22 @@ class _PDFViewScaffoldState extends State<PDFViewerScaffold> {
     }
     return new Scaffold(
         appBar: widget.appBar,
+        bottomNavigationBar: widget.bottomNavigationBar,
         body: const Center(child: const CircularProgressIndicator()));
   }
 
   Rect _buildRect(BuildContext context) {
-    final fullscreen = widget.appBar == null;
+    final shouldOffsetTop = widget.appBar != null;
+    final shouldOffsetBottom = widget.bottomNavigationBar != null;
 
     final mediaQuery = MediaQuery.of(context);
     final topPadding = widget.primary ? mediaQuery.padding.top : 0.0;
     final top =
-    fullscreen ? 0.0 : widget.appBar.preferredSize.height + topPadding;
+    shouldOffsetTop ? widget.appBar.preferredSize.height + topPadding : 0.0;
     var height = mediaQuery.size.height - top;
+    if (shouldOffsetBottom) {
+      height = height - widget.bottomNavigationBar.preferredSize.height;
+    }
     if (height < 0.0) {
       height = 0.0;
     }

--- a/lib/full_pdf_viewer_scaffold.dart
+++ b/lib/full_pdf_viewer_scaffold.dart
@@ -70,11 +70,12 @@ class _PDFViewScaffoldState extends State<PDFViewerScaffold> {
 
     final mediaQuery = MediaQuery.of(context);
     final topPadding = widget.primary ? mediaQuery.padding.top : 0.0;
+    final bottomPadding = widget.primary ? mediaQuery.padding.bottom : 0.0;
     final top =
     shouldOffsetTop ? widget.appBar.preferredSize.height + topPadding : 0.0;
     var height = mediaQuery.size.height - top;
     if (shouldOffsetBottom) {
-      height = height - widget.bottomNavigationBar.preferredSize.height;
+      height = height - widget.bottomNavigationBar.preferredSize.height - bottomPadding;
     }
     if (height < 0.0) {
       height = 0.0;


### PR DESCRIPTION
I see a lot of comments wanting to have floating buttons and other UI with this pdf viewer. I see how they would be difficult (impossible?) to implement.

What I did to get space for more actions/icons is to add support for the bottom navigation bar. This can take any widget you like, it doesn't really need to be navigation at such.

Limitation is that this also need to implement the preferredSize interface so that the height can be determined when sizing the native render rect.

Example invokation:
```
PDFViewerScaffold(
  appBar: buildMyAppBar(),
  bottomNavigationBar: buildMyBottomBar(),
  path: file.path,
)
```

You can get a sized widget easily by wrapping it:
```
PreferredSize(
  preferredSize: Size.fromHeight(kToolbarHeight),
  child: ... Bar, Container, anything within reason ...
)
```

I hope this is not against the principle of this package and that you are ok merging it. 